### PR TITLE
sortメソッドで写真配列をidで並び替え

### DIFF
--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -4,14 +4,15 @@ class PhotosController < ApplicationController
   before_action :search_category_photo, only: [:index, :category, :hashtag, :search]
 
   def index
-    @photos = Photo.order('created_at DESC')
+    @photos = Photo.order(created_at: "DESC")
     # @photos = Photo.all.shuffle
     @followings_photos = []
     if user_signed_in?
       current_user.followings.each do |following|
         @followings_photos.concat(following.photos)
       end
-      @followings_photos.concat(current_user.photos)
+    @my_timeline_photos = @followings_photos.concat(current_user.photos)
+    @my_timeline_photos = @my_timeline_photos.sort { |a, b| b[:id] <=> a[:id] }
     end
   end
 

--- a/app/views/photos/index.html.erb
+++ b/app/views/photos/index.html.erb
@@ -13,7 +13,7 @@
   <% else %>
       <h2 class='title'>マイ タイムライン</h2>
       <ul class='photo-lists'>
-        <%= render partial:"shared/photos", locals: {photos: @followings_photos} %>
+        <%= render partial:"shared/photos", locals: {photos: @my_timeline_photos} %>
       </ul>
       
       <h2 class='title'>最新投稿</h2>


### PR DESCRIPTION
マイタイムラインの写真の並び順を修正しました。
sortメソッドで並び順を変更しました。

# 参照：
## 【Ruby】sortメソッドで配列とHashの中身を並び替える方法
https://pikawaka.com/ruby/sort
sortメソッドは、orderメソッドが使えないときに使える。

## 【Rails】orderメソッドを使って取得したデータを並び替えよう！
https://pikawaka.com/rails/order
orderメソッドは、データベースから取得してきた値を並び替えるときに使える。
データベースの値に他の値を結合した場合、その配列の中身を並び替える場合はorderメソッドが使えずsortメソッドを使うと良い、と理解しました。